### PR TITLE
Fix admin gear toggling staff check

### DIFF
--- a/1rp.Altis/Functions/Admin/fn_toggleAdminGear.sqf
+++ b/1rp.Altis/Functions/Admin/fn_toggleAdminGear.sqf
@@ -9,7 +9,7 @@ _this params [
 	["_force", false, [true]]
 ];
 
-if (isDowned(player) || { !([] call ULP_fnc_isSaff) } || { !(["Suit"] call ULP_fnc_checkPower) }) exitWith { false };
+if (isDowned(player) || { !([] call ULP_fnc_isStaff) } || { !(["Suit"] call ULP_fnc_checkPower) }) exitWith { false };
 
 // Stop spam...
 if (!(_force) && { time < (player getVariable ["admin_cooldown", 0]) }) exitWith {


### PR DESCRIPTION
## Summary
- correct function call when checking staff status in admin gear toggle

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6868b797f7008332a73901cef8a120ea