### PR TITLE
Fix disconnect event params

### DIFF
--- a/@life_server/Addons/life_server/Functions/Events/fn_onPlayerDisconnect.sqf
+++ b/@life_server/Addons/life_server/Functions/Events/fn_onPlayerDisconnect.sqf
@@ -6,7 +6,8 @@
 scopeName "fn_onPlayerDisconnect";
 
 _this params [
-    ["_unit", objNull, [objNull]], "", ["_uid", "", [""]]
+    ["_unit", objNull, [objNull]],
+    ["_uid", "", [""]]
 ];
 
 if (isNull _unit) exitWith {};


### PR DESCRIPTION
## Summary
- adjust param list for player disconnect

## Testing
- `sqflint @life_server/Addons/life_server/Functions/Events/fn_onPlayerDisconnect.sqf`

------
https://chatgpt.com/codex/tasks/task_e_6868babfa9448332b7c504e3604bb3a4