### PR TITLE
Add sqflint linting

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,28 @@
+name: SQF Lint
+
+on:
+  push:
+    paths:
+      - '**/*.sqf'
+      - '.github/workflows/lint.yml'
+      - 'Makefile'
+      - 'requirements.txt'
+  pull_request:
+    paths:
+      - '**/*.sqf'
+      - '.github/workflows/lint.yml'
+      - 'Makefile'
+      - 'requirements.txt'
+
+jobs:
+  sqflint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+      - name: Install dependencies
+        run: pip install -r requirements.txt
+      - name: Run lint
+        run: make lint

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,4 @@
+.PHONY: lint
+
+lint:
+	@sqflint -e e -d .

--- a/README.md
+++ b/README.md
@@ -14,3 +14,14 @@ Players: 130
 www.bydolg.by
 
 Required Mod: https://steamcommunity.com/sharedfiles/filedetails/?id=2966646490
+
+## Development
+
+To lint SQF scripts install the requirements and run:
+
+```bash
+pip install -r requirements.txt
+make lint
+```
+
+A GitHub Actions workflow runs the same check for pull requests.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+sqflint


### PR DESCRIPTION
## Summary
- add sqflint to dev requirements
- provide Makefile target for linting
- document how to run sqflint in README
- run linting in GitHub Actions

## Testing
- `make lint` *(fails: lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_6868c297a054833288c29987900e8cd3