### PR TITLE
Improve hint notifications

### DIFF
--- a/1rp.Altis/CfgNotificationStyles.hpp
+++ b/1rp.Altis/CfgNotificationStyles.hpp
@@ -1,0 +1,14 @@
+class CfgNotificationStyles {
+    class Info {
+        color[] = {0.1, 0.1, 0.1, 0.8};
+        icon = "\a3\ui_f\data\igui\cfg\simpleTasks\types\default_ca.paa";
+    };
+    class Warn : Info {
+        color[] = {1, 0.5, 0, 0.8};
+        icon = "\a3\ui_f\data\igui\cfg\simpleTasks\types\warning_ca.paa";
+    };
+    class Error : Info {
+        color[] = {1, 0, 0, 0.8};
+        icon = "\a3\ui_f\data\igui\cfg\simpleTasks\types\danger_ca.paa";
+    };
+};

--- a/1rp.Altis/Functions/Chat/fn_chatMessage.sqf
+++ b/1rp.Altis/Functions/Chat/fn_chatMessage.sqf
@@ -16,5 +16,5 @@ if !(isClass _cfg || { (count _params) isEqualTo getNumber (_cfg >> "params") } 
 private _msg = [getText (_cfg >> "message")];
 _msg append _params;
 
-systemChat format _msg;
+[format _msg, "", "info"] call ULP_fnc_hint;
 true

--- a/1rp.Altis/Functions/General/fn_logIt.sqf
+++ b/1rp.Altis/Functions/General/fn_logIt.sqf
@@ -17,5 +17,5 @@ private _message = format["[ULP][v%1]%2 %3", LIFE_SETTINGS(getText,"framework_ve
 diag_log _message;
 
 if (hasInterface && { IS_DEBUG_MODE }) then {
-	systemChat _message;
+        [_message, "", "info"] call ULP_fnc_hint;
 };

--- a/1rp.Altis/Functions/Hints/fn_hint.sqf
+++ b/1rp.Altis/Functions/Hints/fn_hint.sqf
@@ -10,8 +10,10 @@ if (canSuspend) exitWith {
 };
 
 _this params [
-	["_text", "", [""]],
-	["_header", "", [""]]
+        ["_text", "", [""]],
+        ["_header", "", [""]],
+        ["_type", "info", [""]],
+        ["_icon", "", [""]]
 ];
 
 private _display = ["RscHints"] call ULP_UI_fnc_getLayer;
@@ -26,8 +28,19 @@ if (count (ULP_eachFrameEvents select { (_x # 0) isEqualTo (["RscHints"] call UL
 };
 
 private _message = _display ctrlCreate [(["ULP_Notification", "ULP_NotificationNoHeader"] select (_header isEqualTo "")), -1];
+private _styleCfg = missionConfigFile >> "CfgNotificationStyles" >> _type;
+private _colour = getArray(_styleCfg >> "color");
+private _iconPath = _icon;
+if (_iconPath isEqualTo "") then {
+    _iconPath = getText(_styleCfg >> "icon");
+};
 private _ctrlText = _message controlsGroupCtrl 102;
 _ctrlText ctrlSetStructuredText parseText _text;
+_ctrlText ctrlSetBackgroundColor _colour;
+(_message controlsGroupCtrl 103) ctrlSetText _iconPath;
+if !(_header isEqualTo "") then {
+    (_message controlsGroupCtrl 101) ctrlSetBackgroundColor _colour;
+};
 
 private _height = ctrlTextHeight _ctrlText;
 

--- a/1rp.Altis/Functions/Input/fn_keyDown.sqf
+++ b/1rp.Altis/Functions/Input/fn_keyDown.sqf
@@ -183,12 +183,12 @@ if (isDowned(player)) then {
                                 _veh setVariable [format ["bis_disabled_Door_%1",_door], 1, true];
                                 _veh animate [format["door_%1_rot",_door],0];
 
-                                systemChat "Вы заперли эту дверь.";
+                                ["Вы заперли эту дверь.", "", "info"] call ULP_fnc_hint;
                             } else {
                                 _veh setVariable [format ["bis_disabled_Door_%1", _door], 0, true];
                                 _veh animate [format["door_%1_rot", _door], 1];
 
-                                systemChat "Вы разблокировали эту дверь.";
+                                ["Вы разблокировали эту дверь.", "", "info"] call ULP_fnc_hint;
                             };
                         };
 
@@ -198,12 +198,12 @@ if (isDowned(player)) then {
                             [_veh, 0] remoteExecCall ["ULP_fnc_lock", _veh];
                             [_veh, "unlockCarSound", 50, 1] remoteExecCall ["ULP_fnc_say3D"];
 
-                            systemChat "Вы разблокировали это транспортное средство.";
+                            ["Вы разблокировали это транспортное средство.", "", "info"] call ULP_fnc_hint;
                         } else {
                             [_veh, 2] remoteExecCall ["ULP_fnc_lock", _veh];
                             [_veh, "lockCarSound", 50, 1] remoteExecCall ["ULP_fnc_say3D"];
 
-                            systemChat "Вы заблокировали это транспортное средство.";
+                            ["Вы заблокировали это транспортное средство.", "", "info"] call ULP_fnc_hint;
                         };
 
                         _handled = true;

--- a/1rp.Altis/Functions/Paycheck/pay.fsm
+++ b/1rp.Altis/Functions/Paycheck/pay.fsm
@@ -49,7 +49,7 @@ class FSM
                 {
                         name = "Split";
                         itemno = 2;
-                        init = /*%FSM<STATEINIT""">*/"systemChat format [""Вы получите денежное пособие через %1 минут."",(getNumber(missionConfigFile >> ""CfgSettings"" >> ""paycheck_period""))];"/*%FSM</STATEINIT""">*/;
+                        init = /*%FSM<STATEINIT""">*/"[format [""Вы получите денежное пособие через %1 минут."",(getNumber(missionConfigFile >> ""CfgSettings"" >> ""paycheck_period""))], "", "info"] call ULP_fnc_hint;"/*%FSM</STATEINIT""">*/;
                         precondition = /*%FSM<STATEPRECONDITION""">*/""/*%FSM</STATEPRECONDITION""">*/;
                         class Links
                         {
@@ -62,11 +62,11 @@ class FSM
                                         precondition = /*%FSM<CONDPRECONDITION""">*/""/*%FSM</CONDPRECONDITION""">*/;
                                         condition=/*%FSM<CONDITION""">*/"(time - _lastcheck) > ((getNumber(missionConfigFile >> ""CfgSettings"" >> ""paycheck_period"")) * 60)"/*%FSM</CONDITION""">*/;
                                         action=/*%FSM<ACTION""">*/"if (!alive player) then {" \n
-                                         "    systemChat ""Вы пропустили выплату пособия за невыполнения условий."";" \n
+                                         "    ["Вы пропустили выплату пособия за невыполнения условий.", "", "info"] call ULP_fnc_hint;" \n
                                          "} else {" \n
                                          "	private _pay = round ((call ULP_Paycheck) + ([""Paychecks""] call ULP_fnc_getLegislation));" \n
                                          "	[_pay, true, ""Paycheck""] call ULP_fnc_addMoney;" \n
-                                         "	systemChat format [""Вы получили пособие $%1."",[_pay] call ULP_fnc_numberText];" \n
+                                         "	[format ["Вы получили пособие $%1.",[_pay] call ULP_fnc_numberText], "", "info"] call ULP_fnc_hint;" \n
                                          "};" \n
                                          "" \n
                                          "_lastcheck = time;" \n

--- a/1rp.Altis/Functions/Stores/fn_addCart.sqf
+++ b/1rp.Altis/Functions/Stores/fn_addCart.sqf
@@ -14,12 +14,12 @@ _this params [
 
 private _display = findDisplay _idd;
 
-if (isNull _display) exitWith { systemChat "Cart Failure" };
+if (isNull _display) exitWith { ["Cart Failure", "", "error"] call ULP_fnc_hint };
 
 private _itemList = _display displayCtrl _itemIdc;
 private _cartList = _display displayCtrl _cartIdc;
 private _textList = _display displayCtrl _textIdc;
-if (isNull _itemList || { isNull _cartList } || { isNull _textList }) exitWith { systemChat "Cart Ctrl Failure" };
+if (isNull _itemList || { isNull _cartList } || { isNull _textList }) exitWith { ["Cart Ctrl Failure", "", "error"] call ULP_fnc_hint };
 
 private _curItem = lbCurSel _itemList;
 

--- a/1rp.Altis/Functions/Stores/fn_onItemClick.sqf
+++ b/1rp.Altis/Functions/Stores/fn_onItemClick.sqf
@@ -12,7 +12,7 @@ _this params [
 private _display = ctrlParent _ctrl;
 private _storeCfg = _display getVariable ["curStore", configNull];
 
-if (!(isClass (_storeCfg)) || { isNull _display }) exitWith { systemChat "Ошибка товара" };
+if (!(isClass (_storeCfg)) || { isNull _display }) exitWith { ["Ошибка товара", "", "error"] call ULP_fnc_hint };
 
 private _data = _ctrl lbData _index;
 if (_data isEqualTo "") exitWith {};

--- a/1rp.Altis/Functions/Stores/fn_onTextureSwitch.sqf
+++ b/1rp.Altis/Functions/Stores/fn_onTextureSwitch.sqf
@@ -12,7 +12,7 @@ _this params [
 private _display = ctrlParent _ctrl;
 private _storeCfg = _display getVariable ["curStore", configNull];
 
-if (!(isClass (_storeCfg)) || { isNull _display }) exitWith { systemChat "Ошибка текстуры" };
+if (!(isClass (_storeCfg)) || { isNull _display }) exitWith { ["Ошибка текстуры", "", "error"] call ULP_fnc_hint };
 
 // Смена картинки...
 private _texture = _ctrl lbData _index;

--- a/1rp.Altis/Functions/Stores/fn_removeCart.sqf
+++ b/1rp.Altis/Functions/Stores/fn_removeCart.sqf
@@ -10,7 +10,7 @@ _this params [
 ];
 
 private _display = ctrlParent _ctrl;
-if (isNull _display) exitWith { systemChat "Ошибка элемента управления корзиной" };
+if (isNull _display) exitWith { ["Ошибка элемента управления корзиной", "", "error"] call ULP_fnc_hint };
 
 // Обновление информации в списке, так как это вызвано с кнопки...
 if (_index isEqualTo -1) then {

--- a/1rp.Altis/Functions/Stores/fn_saveCart.sqf
+++ b/1rp.Altis/Functions/Stores/fn_saveCart.sqf
@@ -8,7 +8,7 @@ scopeName "fn_saveCart";
 private _display = _this param [0, displayNull, [displayNull]];
 private _name = _this param [1, _display getVariable ["saved_cart", ""], [""]];
 
-if (isNull _display || { _name isEqualTo "" }  || { isNil "_name" }) exitWith { systemChat "Произошла ошибка при сохранении корзины"; };
+if (isNull _display || { _name isEqualTo "" }  || { isNil "_name" }) exitWith { ["Произошла ошибка при сохранении корзины", "", "error"] call ULP_fnc_hint; };
 
 private _storeCfgName = format["%1%2", configName (_display getVariable "storeCfg"), configName (_display getVariable "curStore")];
 private _allSavedCarts = + (profileNamespace getVariable ["ULP_SavedCarts", createHashMap]);

--- a/1rp.Altis/Functions/Stores/fn_switchCategory.sqf
+++ b/1rp.Altis/Functions/Stores/fn_switchCategory.sqf
@@ -12,7 +12,7 @@ _this params [
 private _display = ctrlParent _ctrl;
 private _storeCfg = _display getVariable ["curStore", configNull];
 
-if (!(isClass (_storeCfg)) || { isNull _display }) exitWith { systemChat "Ошибка выбора категории" };
+if (!(isClass (_storeCfg)) || { isNull _display }) exitWith { ["Ошибка выбора категории", "", "error"] call ULP_fnc_hint };
 
 private _itemList = _display displayCtrl 3103;
 lbClear _itemList;

--- a/1rp.Altis/UI/common.hpp
+++ b/1rp.Altis/UI/common.hpp
@@ -1798,12 +1798,20 @@ class ULP_Notification : Life_RscControlsGroupNoScrollbars {
             w = 11 * GUI_GRID_CENTER_W;
             h = 0.75 * GUI_GRID_CENTER_H;
         };
+        class Icon: Life_RscPictureKeepAspect {
+            idc = 103;
+            y = 0.75 * GUI_GRID_CENTER_H;
+            w = 1 * GUI_GRID_CENTER_W;
+            h = 1 * GUI_GRID_CENTER_H;
+        };
         class Body : Header {
             idc = 102;
             style = "0x10";
             text = "This is a notification";
             colorBackground[] = {0.1, 0.1, 0.1, 0.8};
+            x = 1 * GUI_GRID_CENTER_W;
             y = 0.75 * GUI_GRID_CENTER_H;
+            w = 10 * GUI_GRID_CENTER_W;
             h = 1 * GUI_GRID_CENTER_H;
         };
     };
@@ -1813,12 +1821,18 @@ class ULP_NotificationNoHeader : ULP_Notification {
     h = 1 * GUI_GRID_CENTER_H;
 
     class Controls {
+        class Icon: Life_RscPictureKeepAspect {
+            idc = 103;
+            w = 1 * GUI_GRID_CENTER_W;
+            h = 1 * GUI_GRID_CENTER_H;
+        };
         class Body : Life_RscStructuredText {
             idc = 102;
             style = "0x10";
             text = "This is a notification";
             colorBackground[] = {0.1, 0.1, 0.1, 0.8};
-            w = 11 * GUI_GRID_CENTER_W;
+            x = 1 * GUI_GRID_CENTER_W;
+            w = 10 * GUI_GRID_CENTER_W;
             h = 1 * GUI_GRID_CENTER_H;
         };
     };

--- a/1rp.Altis/description.ext
+++ b/1rp.Altis/description.ext
@@ -42,6 +42,7 @@ class CfgWorlds {
 #include "CfgDisabledCommands.hpp"
 #include "CfgFunctions.hpp"
 #include "CfgNotifications.hpp"
+#include "CfgNotificationStyles.hpp"
 #include "CfgRemoteExec.hpp"
 #include "CfgSFX.hpp"
 #include "CfgSounds.hpp"

--- a/README.md
+++ b/README.md
@@ -14,3 +14,8 @@ Players: 130
 www.bydolg.by
 
 Required Mod: https://steamcommunity.com/sharedfiles/filedetails/?id=2966646490
+
+## Notification hints
+Use `[text, header, type, icon] call ULP_fnc_hint` to display messages to the player.
+`type` controls the background colour and icon (`info`, `warn` or `error`).
+The styles are defined in `CfgNotificationStyles.hpp`.


### PR DESCRIPTION
## Summary
- extend `fn_hint` parameters with type and icon
- theme notification controls with icon and colours
- add notification style config
- replace `systemChat` calls with `ULP_fnc_hint`
- document the new hint usage

## Testing
- `git log -1 --stat`


------
https://chatgpt.com/codex/tasks/task_e_6868ccfb2c688332884641e5cd877b0c