### PR TITLE
Add localization support

### DIFF
--- a/1rp.Altis/Functions/Chat/CfgChat.hpp
+++ b/1rp.Altis/Functions/Chat/CfgChat.hpp
@@ -1,55 +1,55 @@
 class CfgChat {
 	class Messages {
-		class Injured {
-			message = "%1 был серьезно ранен";
-			params = 1;
+                class Injured {
+                        message = "$STR_CHAT_INJURED";
+                        params = 1;
 			condition = "[[""EnableMessagesIncapacitated"", ""Chat""] call ULP_fnc_getOption] call ULP_fnc_bool";
 		};
-		class Bleedout : Injured {
-			message = "%1 истекает кровью...";
-		};
-		class Executed {
-			message = "%1 был казнен %2";
+                class Bleedout : Injured {
+                        message = "$STR_CHAT_BLEEDOUT";
+                };
+                class Executed {
+                        message = "$STR_CHAT_EXECUTED";
 			params = 2;
 			condition = "[[""EnableMessagesBleedout"", ""Chat""] call ULP_fnc_getOption] call ULP_fnc_bool";
 		};
-		class InjuredBy : Executed {
-			message = "%1 был серьезно ранен %2";
-		};
-		class Revived : Executed {
-			message = "%1 был возрожден %2";
-			condition = "[[""EnableMessagesRevived"", ""Chat""] call ULP_fnc_getOption] call ULP_fnc_bool";
-		};
-		class Prisoned {
-			message = "%1 был заключен в тюрьму %2 на %3 минуты";
+                class InjuredBy : Executed {
+                        message = "$STR_CHAT_INJURED_BY";
+                };
+                class Revived : Executed {
+                        message = "$STR_CHAT_REVIVED";
+                        condition = "[[""EnableMessagesRevived"", ""Chat""] call ULP_fnc_getOption] call ULP_fnc_bool";
+                };
+                class Prisoned {
+                        message = "$STR_CHAT_PRISONED";
 			params = 3;
 			condition = "[[""EnableMessagesPrisoned"", ""Chat""] call ULP_fnc_getOption] call ULP_fnc_bool";
 		};
-		class Garaged : Prisoned {
-			message = "%2 %1 был поставлен в гараж %3";
-			condition = "[[""EnableMessagesVehicle"", ""Chat""] call ULP_fnc_getOption] call ULP_fnc_bool";
-		};
-		class Crushed : Garaged {
-			message = "%2 владельца %1 был уничтожен %3";
-		};
-		class Impounded : Garaged {
-			message = "%2 владельца %1 был конфискован %3 для %4";
-			params = 4;
-		};
-		class IssuedFine : Prisoned {
-			message = "%1 выписал %2 штраф в размере %3";
+                class Garaged : Prisoned {
+                        message = "$STR_CHAT_GARAGED";
+                        condition = "[[""EnableMessagesVehicle"", ""Chat""] call ULP_fnc_getOption] call ULP_fnc_bool";
+                };
+                class Crushed : Garaged {
+                        message = "$STR_CHAT_CRUSHED";
+                };
+                class Impounded : Garaged {
+                        message = "$STR_CHAT_IMPOUNDED";
+                        params = 4;
+                };
+                class IssuedFine : Prisoned {
+                        message = "$STR_CHAT_ISSUEDFINE";
 			condition = "[[""EnableMessagesTicket"", ""Chat""] call ULP_fnc_getOption] call ULP_fnc_bool";
 		};
-		class FinePaid : IssuedFine {
-			message = "%1 заплатил штраф в размере %2";
-			params = 2;
-		};
-		class FineRefused : FinePaid {
-			message = "%1 отказался от штрафа в размере %2";
-		};
-		class FinePoor : FinePaid {
-			message = "%1 не может позволить себе штраф в размере %2";
-		};
+                class FinePaid : IssuedFine {
+                        message = "$STR_CHAT_FINEPAID";
+                        params = 2;
+                };
+                class FineRefused : FinePaid {
+                        message = "$STR_CHAT_FINEREFUSED";
+                };
+                class FinePoor : FinePaid {
+                        message = "$STR_CHAT_FINEPOOR";
+                };
 	};
 	class Commands {
 		class Players {

--- a/1rp.Altis/Functions/Vehicle/fn_impoundVehicle.sqf
+++ b/1rp.Altis/Functions/Vehicle/fn_impoundVehicle.sqf
@@ -18,11 +18,11 @@ _cfg params [
 
 if !(isClass _missionCfg) exitWith {};
 if !([player, ["Police", "Hato"]] call ULP_fnc_isFaction) exitWith {
-	["Только полиция и ХАТО могут изъять транспортные средства"] call ULP_fnc_hint;
+        [LSTRING(IMPOUND_ONLY_POLICE)] call ULP_fnc_hint;
 };
 
 if !((crew _vehicle) isEqualTo []) exitWith {
-	["Никто не может находиться в транспортном средстве при его изъятии!"] call ULP_fnc_hint;
+        [LSTRING(IMPOUND_NOBODY)] call ULP_fnc_hint;
 };
 
 private _time = ["StreetCleaner", getNumber (missionConfigFile >> "CfgSettings" >> "Police" >> "impoundTime")] call ULP_fnc_activatePerk;
@@ -31,7 +31,7 @@ if (isNumber (_missionCfg >> "impoundTime")) then {
 };
 
 if ((_vehicle getVariable ["vehicle_id", -1]) < 0) exitWith {
-	["Арендованные транспортные средства не могут быть изъяты!"] call ULP_fnc_hint;
+        [LSTRING(IMPOUND_RENTAL)] call ULP_fnc_hint;
 };
 
 [
@@ -42,32 +42,32 @@ if ((_vehicle getVariable ["vehicle_id", -1]) < 0) exitWith {
 			["_fee", 1, [0]] 
 		];
 
-		if !([format["Изъятие %1", _name], _time, [_vehicle, _name, _fee], {
+		if !([format[localize LSTRING(IMPOUND_PROGRESS), _name], _time, [_vehicle, _name, _fee], {
 			!(isNull (_this select 0)) && { alive (_this select 0) } && { (player distance (_this select 0)) <= 5 }
 		}, {
 			_this params [ "_vehicle", "_name", "_fee" ];
 
 			if (isNull _vehicle || { !((crew _vehicle) isEqualTo []) }) exitWith {
-				[format["Вы не смогли изъять это транспортное средство, так как в нем кто-то находился, или оно уже было удалено!"]] call ULP_fnc_hint;
+                                [LSTRING(IMPOUND_FAILED)] call ULP_fnc_hint;
 			};
 
 			private _id = _vehicle getVariable ["vehicle_id", -1];
 
 			if (_id < 0) exitWith {
-				["Арендованные транспортные средства не могут быть изъяты!"] call ULP_fnc_hint;
+                                [LSTRING(IMPOUND_RENTAL)] call ULP_fnc_hint;
 			};
 
 			private _owner = (_vehicle getVariable ["vehicle_owners", createHashMap]) getOrDefault [[_vehicle] call ULP_fnc_getVehicleOwner, []];
 
 			["Первое изъятие"] call ULP_fnc_achieve;
 
-			[format["Вы запросили изъятие <t color='#B92DE0'>%1</t> за плату в <t color='#B92DE0'>%2%3</t>.", _name, "$", [_fee] call ULP_fnc_numberText]] call ULP_fnc_hint;
-			["Транспортное средство изъято", { hint "Транспортное средство изъято."; }, true] call ULP_fnc_addEventHandler;
+                        [format[localize LSTRING(IMPOUND_REQUEST), _name, "$", [_fee] call ULP_fnc_numberText]] call ULP_fnc_hint;
+                        [LSTRING(IMPOUND_DONE_TITLE), { hint localize LSTRING(IMPOUND_DONE_HINT); }, true] call ULP_fnc_addEventHandler;
 			[_vehicle, _fee] remoteExecCall ["ULP_SRV_fnc_storeVehicle", RSERV];
 
-			["Изъято", [_owner param [0, "Кто-то"], _name, [player, true] call ULP_fnc_getName, format ["%1%2", "$", [_fee] call ULP_fnc_numberText]]] remoteExecCall ["ULP_fnc_chatMessage", RCLIENT];
+                        [LSTRING(CHAT_IMPOUNDED_NOTIFY), [_owner param [0, "Кто-то"], _name, [player,true] call ULP_fnc_getName, format ["%1%2", "$", [_fee] call ULP_fnc_numberText]]] remoteExecCall ["ULP_fnc_chatMessage", RCLIENT];
 		}, {}] call ULP_UI_fnc_startProgress) exitWith {
-			["Вы не можете изъять транспортное средство, выполняя другое действие!"] call ULP_fnc_hint;
+                        [LSTRING(IMPOUND_BUSY)] call ULP_fnc_hint;
 		};
 
 		closeDialog 0;

--- a/1rp.Altis/Stringtable.xml
+++ b/1rp.Altis/Stringtable.xml
@@ -1,0 +1,97 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project name="1rp">
+    <Package name="1rp">
+        <Key ID="STR_IMPOUND_ONLY_POLICE">
+            <Original>Только полиция и ХАТО могут изъять транспортные средства</Original>
+            <English>Only Police and HATO can impound vehicles</English>
+        </Key>
+        <Key ID="STR_IMPOUND_NOBODY">
+            <Original>Никто не может находиться в транспортном средстве при его изъятии!</Original>
+            <English>Nobody can be inside the vehicle when impounding!</English>
+        </Key>
+        <Key ID="STR_IMPOUND_RENTAL">
+            <Original>Арендованные транспортные средства не могут быть изъяты!</Original>
+            <English>Rental vehicles cannot be impounded!</English>
+        </Key>
+        <Key ID="STR_IMPOUND_FAILED">
+            <Original>Вы не смогли изъять это транспортное средство, так как в нем кто-то находился, или оно уже было удалено!</Original>
+            <English>You failed to impound this vehicle because someone was inside or it was already removed!</English>
+        </Key>
+        <Key ID="STR_IMPOUND_REQUEST">
+            <Original>Вы запросили изъятие &lt;t color='#B92DE0'&gt;%1&lt;/t&gt; за плату в &lt;t color='#B92DE0'&gt;%2%3&lt;/t&gt;.</Original>
+            <English>You requested the impounding of &lt;t color='#B92DE0'&gt;%1&lt;/t&gt; for a fee of &lt;t color='#B92DE0'&gt;%2%3&lt;/t&gt;.</English>
+        </Key>
+        <Key ID="STR_IMPOUND_DONE_TITLE">
+            <Original>Транспортное средство изъято</Original>
+            <English>Vehicle impounded</English>
+        </Key>
+        <Key ID="STR_IMPOUND_DONE_HINT">
+            <Original>Транспортное средство изъято.</Original>
+            <English>Vehicle impounded.</English>
+        </Key>
+        <Key ID="STR_IMPOUND_BUSY">
+            <Original>Вы не можете изъять транспортное средство, выполняя другое действие!</Original>
+            <English>You cannot impound a vehicle while performing another action!</English>
+        </Key>
+        <Key ID="STR_IMPOUND_PROGRESS">
+            <Original>Изъятие %1</Original>
+            <English>Impounding %1</English>
+        </Key>
+        <Key ID="STR_CHAT_IMPOUNDED_NOTIFY">
+            <Original>Изъято</Original>
+            <English>Impounded</English>
+        </Key>
+        <Key ID="STR_CHAT_INJURED">
+            <Original>%1 был серьезно ранен</Original>
+            <English>%1 was seriously injured</English>
+        </Key>
+        <Key ID="STR_CHAT_BLEEDOUT">
+            <Original>%1 истекает кровью...</Original>
+            <English>%1 is bleeding out...</English>
+        </Key>
+        <Key ID="STR_CHAT_EXECUTED">
+            <Original>%1 был казнен %2</Original>
+            <English>%1 was executed by %2</English>
+        </Key>
+        <Key ID="STR_CHAT_INJURED_BY">
+            <Original>%1 был серьезно ранен %2</Original>
+            <English>%1 was seriously injured by %2</English>
+        </Key>
+        <Key ID="STR_CHAT_REVIVED">
+            <Original>%1 был возрожден %2</Original>
+            <English>%1 was revived by %2</English>
+        </Key>
+        <Key ID="STR_CHAT_PRISONED">
+            <Original>%1 был заключен в тюрьму %2 на %3 минуты</Original>
+            <English>%1 was jailed by %2 for %3 minutes</English>
+        </Key>
+        <Key ID="STR_CHAT_GARAGED">
+            <Original>%2 %1 был поставлен в гараж %3</Original>
+            <English>%2 %1 was garaged by %3</English>
+        </Key>
+        <Key ID="STR_CHAT_CRUSHED">
+            <Original>%2 владельца %1 был уничтожен %3</Original>
+            <English>%2 belonging to %1 was destroyed by %3</English>
+        </Key>
+        <Key ID="STR_CHAT_IMPOUNDED">
+            <Original>%2 владельца %1 был конфискован %3 для %4</Original>
+            <English>%2 belonging to %1 was impounded by %3 for %4</English>
+        </Key>
+        <Key ID="STR_CHAT_ISSUEDFINE">
+            <Original>%1 выписал %2 штраф в размере %3</Original>
+            <English>%1 issued %2 a fine of %3</English>
+        </Key>
+        <Key ID="STR_CHAT_FINEPAID">
+            <Original>%1 заплатил штраф в размере %2</Original>
+            <English>%1 paid a fine of %2</English>
+        </Key>
+        <Key ID="STR_CHAT_FINEREFUSED">
+            <Original>%1 отказался от штрафа в размере %2</Original>
+            <English>%1 refused a fine of %2</English>
+        </Key>
+        <Key ID="STR_CHAT_FINEPOOR">
+            <Original>%1 не может позволить себе штраф в размере %2</Original>
+            <English>%1 cannot afford a fine of %2</English>
+        </Key>
+    </Package>
+</Project>

--- a/1rp.Altis/description.ext
+++ b/1rp.Altis/description.ext
@@ -1,3 +1,6 @@
+class CfgPatches { class _1rp { units[] = {}; weapons[] = {}; requiredVersion = 1.0; requiredAddons[] = {}; }; };
+class CfgLanguages { class English; class Russian; };
+
 overviewText = "A roleplaying gamemode developed by [bydolg] based by Scarso and Lewis!";
 disableRandomization[]= { "All" };
 joinUnassigned = 1;

--- a/1rp.Altis/script_macros.hpp
+++ b/1rp.Altis/script_macros.hpp
@@ -22,3 +22,4 @@
 #define FETCH_CONST(var) (call var)
 
 #define LIFE_SETTINGS(TYPE,SETTING) TYPE(missionConfigFile >> "CfgSettings" >> SETTING)
+#define LSTRING(var) (localize format["STR_%1", var])


### PR DESCRIPTION
## Summary
- add `Stringtable.xml` with English and Russian text
- use localization keys in impound vehicle logic
- use localization keys in chat config
- add `LSTRING` macro
- register new stringtable in `description.ext`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6869ed2bb2388332b6cc407abfa858ed