### PR TITLE
Fix language-specific chat messages

### DIFF
--- a/1rp.Altis/Functions/Medical/fn_revived.sqf
+++ b/1rp.Altis/Functions/Medical/fn_revived.sqf
@@ -20,7 +20,7 @@ if ([_medic] call ULP_fnc_onDuty) then {
 };
 
 if !(player isEqualTo _medic) then {
-	["Оживил", [name player, [[_medic, true] call ULP_fnc_getName, "администратор"] select ([_medic] call ULP_fnc_onDuty)]] remoteExecCall ["ULP_fnc_chatMessage", RCLIENT];
+        ["Revived", [name player, [[_medic, true] call ULP_fnc_getName, "администратор"] select ([_medic] call ULP_fnc_onDuty)]] remoteExecCall ["ULP_fnc_chatMessage", RCLIENT];
 
 	// У нас высокая репутация, поэтому человек, который вас оживил, получит репутацию в ответ
 	if (ULP_Reputation >= 500) then {

--- a/1rp.Altis/Functions/Vehicle/fn_crushVehicle.sqf
+++ b/1rp.Altis/Functions/Vehicle/fn_crushVehicle.sqf
@@ -50,7 +50,7 @@ if !([format["Уничтожение %1", _name], _time, [_vehicle, _name, _fee]
 	["FirstCrush"] call ULP_fnc_achieve;
 
 	["Транспортное средство было уничтожено!"] call ULP_fnc_hint;
-	["Уничтожено", [_owner param [0, "Кто-то"], _name, [player, true] call ULP_fnc_getName]] remoteExecCall ["ULP_fnc_chatMessage", RCLIENT];
+        ["Crushed", [_owner param [0, "Кто-то"], _name, [player, true] call ULP_fnc_getName]] remoteExecCall ["ULP_fnc_chatMessage", RCLIENT];
 }, {}] call ULP_UI_fnc_startProgress) exitWith {
 	["Вы не можете уничтожать транспортное средство, выполняя другое действие!"] call ULP_fnc_hint;
 };

--- a/1rp.Altis/Functions/Vehicle/fn_garageVehicle.sqf
+++ b/1rp.Altis/Functions/Vehicle/fn_garageVehicle.sqf
@@ -48,7 +48,7 @@ if !([format["Хранение %1", _name], _time, [_vehicle, _name], {
 		["Транспортное средство сохранено."] call ULP_fnc_hint;
 	};
 
-	["Гараж", [_owner param [0, "Кто-то"], _name, [player, true] call ULP_fnc_getName]] remoteExecCall ["ULP_fnc_chatMessage", RCLIENT];
+        ["Garaged", [_owner param [0, "Кто-то"], _name, [player, true] call ULP_fnc_getName]] remoteExecCall ["ULP_fnc_chatMessage", RCLIENT];
 }, {}] call ULP_UI_fnc_startProgress) exitWith {
 	["Вы не можете поместить транспортное средство в гараж, выполняя другое действие!"] call ULP_fnc_hint;
 };

--- a/1rp.Altis/Functions/Vehicle/fn_impoundVehicle.sqf
+++ b/1rp.Altis/Functions/Vehicle/fn_impoundVehicle.sqf
@@ -65,7 +65,7 @@ if ((_vehicle getVariable ["vehicle_id", -1]) < 0) exitWith {
                         [LSTRING(IMPOUND_DONE_TITLE), { hint LSTRING(IMPOUND_DONE_HINT); }, true] call ULP_fnc_addEventHandler;
 			[_vehicle, _fee] remoteExecCall ["ULP_SRV_fnc_storeVehicle", RSERV];
 
-                        [LSTRING(CHAT_IMPOUNDED_NOTIFY), [_owner param [0, "Кто-то"], _name, [player,true] call ULP_fnc_getName, format ["%1%2", "$", [_fee] call ULP_fnc_numberText]]] remoteExecCall ["ULP_fnc_chatMessage", RCLIENT];
+                        ["Impounded", [_owner param [0, "Кто-то"], _name, [player,true] call ULP_fnc_getName, format ["%1%2", "$", [_fee] call ULP_fnc_numberText]]] remoteExecCall ["ULP_fnc_chatMessage", RCLIENT];
 		}, {}] call ULP_UI_fnc_startProgress) exitWith {
                         [LSTRING(IMPOUND_BUSY)] call ULP_fnc_hint;
 		};


### PR DESCRIPTION
## Summary
- translate chat notifications for impound, garage, crush, and revive actions

## Testing
- `make lint` *(fails: No rule to make target 'lint')*

------
https://chatgpt.com/codex/tasks/task_e_686ebcacde08833287400943552b4f40