### PR TITLE
Fix chat message option checks

### DIFF
--- a/1rp.Altis/Functions/Chat/fn_chatMessage.sqf
+++ b/1rp.Altis/Functions/Chat/fn_chatMessage.sqf
@@ -11,7 +11,11 @@ _this params [
 ];
 
 private _cfg = missionConfigFile >> "CfgChat" >> "Messages" >> _message;
-if !(isClass _cfg || { (count _params) isEqualTo getNumber (_cfg >> "params") } || { !(call compile getText (_cfg >> "condition")) }) exitWith { false };
+if !(
+    isClass _cfg &&
+    { (count _params) isEqualTo getNumber (_cfg >> "params") } &&
+    { call compile getText (_cfg >> "condition") }
+) exitWith { false };
 
 private _msg = [getText (_cfg >> "message")];
 _msg append _params;


### PR DESCRIPTION
## Summary
- fix logical check for chat messages to ensure config, params, and condition

## Testing
- `make lint` *(fails: No rule to make target)*

------
https://chatgpt.com/codex/tasks/task_e_686ece4d06008332b8ff57417b4d0821