### PR TITLE
Add localization for PNC, admin camera and spawn points

### DIFF
--- a/1rp.Altis/Functions/Admin/fn_adminCamera.sqf
+++ b/1rp.Altis/Functions/Admin/fn_adminCamera.sqf
@@ -118,13 +118,13 @@ switch (_mode) do {
 
 		if !(["Teleport"] call ULP_fnc_checkPower) exitWith {};
 
-		if (time < (player getVariable ["admin_action_cooldown", 0])) exitWith {
-                        ["Вы недавно использовали команду, пожалуйста, подождите перед повторной попыткой..."] call ULP_fnc_hint;
-			false
-		};
+                if (time < (player getVariable ["admin_action_cooldown", 0])) exitWith {
+                        [LSTRING(ADMIN_COOLDOWN)] call ULP_fnc_hint;
+                        false
+                };
 
-		private _focus = ["GetCameraTarget"] call ULP_fnc_adminCamera;
-                if (isNull _focus) exitWith { ["Вам нужно выбрать цель для выполнения этого действия..."] call ULP_fnc_hint; };
+                private _focus = ["GetCameraTarget"] call ULP_fnc_adminCamera;
+                if (isNull _focus) exitWith { [LSTRING(ADMIN_NEED_TARGET)] call ULP_fnc_hint; };
 
 		player setVariable ["admin_action_cooldown", time + 2];
 
@@ -135,18 +135,18 @@ switch (_mode) do {
 				[getPlayerUID player, "Admin", ["AdminEjectVehicle", serverTime, [name _focus, getPlayerUID _focus, getPos _focus]]] remoteExecCall ["ULP_SRV_fnc_logPlayerEvent", RSERV];
 			};
 
-                        if (_focus isEqualTo player) exitWith { ["Нельзя выполнить это действие на себе..."] call ULP_fnc_hint; };
-                        if !(isNull (objectParent player)) exitWith { ["Вам нужно выйти из транспортного средства, прежде чем сделать это..."] call ULP_fnc_hint; };
+                        if (_focus isEqualTo player) exitWith { [LSTRING(ADMIN_TARGET_SELF)] call ULP_fnc_hint; };
+                        if !(isNull (objectParent player)) exitWith { [LSTRING(ADMIN_EXIT_VEHICLE)] call ULP_fnc_hint; };
 
 			case "To": {	
-				player setPos (getPos _focus);
-                                [format ["Вы телепортировались к <t color='#B92DE0'>%1</t>", name _focus]] call ULP_fnc_hint;
+                                player setPos (getPos _focus);
+                                [format [LSTRING(ADMIN_TELEPORT_TO), name _focus]] call ULP_fnc_hint;
 				[getPlayerUID player, "Admin", ["AdminTeleportTo", serverTime, [name _focus, getPlayerUID _focus, getPos _focus]]] remoteExecCall ["ULP_SRV_fnc_logPlayerEvent", RSERV];
 			};
 
 			case "Here": {
-				_focus setPos (getPos player);
-                                [format ["Вы телепортировали <t color='#B92DE0'>%1</t> к себе", name _focus]] call ULP_fnc_hint;
+                                _focus setPos (getPos player);
+                                [format [LSTRING(ADMIN_TELEPORT_HERE), name _focus]] call ULP_fnc_hint;
 				[getPlayerUID player, "Admin", ["AdminTeleportHere", serverTime, [name _focus, getPlayerUID _focus, getPos _focus]]] remoteExecCall ["ULP_SRV_fnc_logPlayerEvent", RSERV];
 			};
 			

--- a/1rp.Altis/Functions/PNC/fn_clearWarrants.sqf
+++ b/1rp.Altis/Functions/PNC/fn_clearWarrants.sqf
@@ -22,12 +22,12 @@ private _path = tvCurSel _list;
 
 private _unit = [_list tvData _path] call ULP_fnc_playerByUid;
 if (isNull _unit) exitWith {
-	["Вы должны выбрать ордер, который вы хотите удалить..."] call ULP_fnc_hint;
+        [LSTRING(PNC_SELECT_WARRANT)] call ULP_fnc_hint;
 };
 
 [
 	(findDisplay getNumber(configFile >> "RscDisplayMission" >> "idd")), "Confirmation", ["Clear", "Cancel"],
-	format ["Вы уверены, что хотите очистить ордера для %1...", name _unit], [_unit, _display, _list, _path],
+        format [LSTRING(PNC_CLEAR_CONFIRM), name _unit], [_unit, _display, _list, _path],
 	{	
 		_this params [ "_unit", "_display", "_list", "_path" ];
 		
@@ -39,7 +39,7 @@ if (isNull _unit) exitWith {
 
 		_list tvDelete _path;
 
-		[getPlayerUID _unit] remoteExecCall ["ULP_SRV_fnc_clearWarrants", RSERV];
-		[format ["Вы очистили ордера для <t color='#B92DE0'>%1</t>", name _unit]] call ULP_fnc_hint;
+                [getPlayerUID _unit] remoteExecCall ["ULP_SRV_fnc_clearWarrants", RSERV];
+                [format [LSTRING(PNC_CLEARED), name _unit]] call ULP_fnc_hint;
 	}, {}, false
 ] call ULP_fnc_confirm;

--- a/1rp.Altis/Functions/Spawn/CfgSpawns.hpp
+++ b/1rp.Altis/Functions/Spawn/CfgSpawns.hpp
@@ -28,34 +28,34 @@ class CfgSpawns {
     class Altis {
         // Altis Police Service
         class KavalaStation : Police {
-            displayName = "Штаб-квартира Кавалы";
+            displayName = $STR_SPAWN_KAVALA_HQ;
             marker = "apc_spawn_kavala";
             icon = "\dataM\UI\Spawns\kavala.paa";
         };
         class KavalaStationNCA : Civilian {
-            displayName = "Штаб-квартира НСА на передовой";
+            displayName = $STR_SPAWN_NCA_FRONTLINE;
             marker = "apc_spawn_nca";
             icon = "\dataM\UI\Spawns\kavala.paa";
             radius = 1;
             conditions = "[] call ULP_fnc_isUndercover";
         };
         class AthiraStation : Police {
-            displayName = "Пост Афиры";
+            displayName = $STR_SPAWN_ATHIRA_POST;
             marker = "apc_spawn_athira";
             icon = "\dataM\UI\Spawns\athira.paa";
         };
         class PyrgosStation : Police {
-            displayName = "Пост Пироса";
+            displayName = $STR_SPAWN_PYRGOS_POST;
             marker = "apc_spawn_pyrgos";
             icon = "\dataM\UI\Spawns\pyrgos.paa";
         };
         class AgiosStation : Police {
-            displayName = "Пост Агиоса";
+            displayName = $STR_SPAWN_AGIOS_POST;
             marker = "apc_spawn_agios";
             icon = "\dataM\UI\Spawns\agios.paa";
         };
         class UndercoverHeadquarters : BaseSpawn {
-            displayName = "Скрытая штаб-квартира НСА";
+            displayName = $STR_SPAWN_UNDERCOVER_HQ;
             marker = "apc_spawn_uc";
             icon = "\dataM\UI\Spawns\neochori.paa";
             radius = 1;
@@ -64,22 +64,22 @@ class CfgSpawns {
 
         // Altis Ambulance Service
         class KavalaHospital : Medic {
-            displayName = "Госпиталь Кавалы";
+            displayName = $STR_SPAWN_KAVALA_HOSPITAL;
             marker = "nhs_spawn_kavala";
             icon = "\dataM\UI\Spawns\kavala.paa";
         };
         class AthiraClinic : Medic {
-            displayName = "Клиника Афиры";
+            displayName = $STR_SPAWN_ATHIRA_CLINIC;
             marker = "nhs_spawn_athira";
             icon = "\dataM\UI\Spawns\athira.paa";
         };
         class PyrgosClinic : Medic {
-            displayName = "Клиника Пироса";
+            displayName = $STR_SPAWN_PYRGOS_CLINIC;
             marker = "nhs_spawn_pyrgos";
             icon = "\dataM\UI\Spawns\pyrgos.paa";
         };
         class AirAmbulance : Medic {
-            displayName = "Станция Воздушной скорой помощи";
+            displayName = $STR_SPAWN_AIR_AMBULANCE;
             marker = "nhs_spawn_aa";
             icon = "\dataM\UI\Spawns\idap.paa";
             conditions = "[""Medic_AA"", 1] call ULP_fnc_hasAccess";
@@ -87,7 +87,7 @@ class CfgSpawns {
 
         // Altis Police Service / Altis Ambulance Service
         class MarineStation : Police {
-            displayName = "Морская база";
+            displayName = $STR_SPAWN_MARINE_BASE;
             factions[] = { "Police", "Medic" };
             marker = "joint_spawn_marine";
             icon = "\dataM\UI\Spawns\marine.paa";
@@ -95,92 +95,92 @@ class CfgSpawns {
 
         // HATO
         class HatoKavala : HATO {
-            displayName = "Объект Кавалы";
+            displayName = $STR_SPAWN_HATO_KAVALA;
             marker = "hato_spawn_kavala";
             icon = "\dataM\UI\Spawns\kavala.paa";
         };
         class HatoAgios : HATO {
-            displayName = "Объект Агиоса";
+            displayName = $STR_SPAWN_HATO_AGIOS;
             marker = "hato_spawn_agios";
             icon = "\dataM\UI\Spawns\agios.paa";
         };
 
         // Government
         class GovernorResidence : BaseSpawn {
-            displayName = "10 улица Кавалы";
+            displayName = $STR_SPAWN_GOV_RESIDENCE;
             marker = "civ_spawn_residence";
             icon = "\dataM\UI\Spawns\government.paa";
             conditions = "[] call ULP_fnc_isGovernor || { [] call ULP_fnc_isProtection }";
         };
         class GovernmentOffices : GovernorResidence {
-            displayName = "Правительственные офисы";
+            displayName = $STR_SPAWN_GOV_OFFICES;
             marker = "civ_spawn_government";
         };
         class KavalaSafehouse : GovernorResidence {
-            displayName = "Тайник Кавалы";
+            displayName = $STR_SPAWN_KAVALA_SAFEHOUSE;
             marker = "civ_spawn_kavSafehouse";
             conditions = "[] call ULP_fnc_isGovernor || { [] call ULP_fnc_isProtection && { [""GovernmentSafehouses""] call ULP_fnc_hasGroupPerk } }";
         };
         class PyrgosSafehouse : KavalaSafehouse {
-            displayName = "Тайник Пироса";
+            displayName = $STR_SPAWN_PYRGOS_SAFEHOUSE;
             marker = "civ_spawn_pyrSafehouse";
         };
         
         // Civilian
         class Kavala : Civilian {
-            displayName = "Кавала";
+            displayName = $STR_SPAWN_CIV_KAVALA;
             marker = "civ_spawn_kavala";
             icon = "\dataM\UI\Spawns\kavala.paa";
         };
         class Athira : Civilian {
-            displayName = "Афира";
+            displayName = $STR_SPAWN_CIV_ATHIRA;
             marker = "civ_spawn_athira";
             icon = "\dataM\UI\Spawns\athira.paa";
         };
         class Pyrgos : Civilian {
-            displayName = "Пирогос";
+            displayName = $STR_SPAWN_CIV_PYRGOS;
             marker = "civ_spawn_pyrgos";
             icon = "\dataM\UI\Spawns\pyrgos.paa";
         };
         class Sofia : Civilian {
-            displayName = "София";
+            displayName = $STR_SPAWN_CIV_SOFIA;
             marker = "civ_spawn_sofia";
             icon = "\dataM\UI\Spawns\sofia.paa";
             conditions = "[""WideTraveller""] call ULP_fnc_hasPerk";
         };
         class Agios : Civilian {
-            displayName = "Агиос";
+            displayName = $STR_SPAWN_CIV_AGIOS;
             marker = "civ_spawn_agios";
             icon = "\dataM\UI\Spawns\agios.paa";
             conditions = "[""WideTraveller""] call ULP_fnc_hasPerk";
         };
         class Neochori : Civilian {
-            displayName = "Неохори";
+            displayName = $STR_SPAWN_CIV_NEOCHORI;
             marker = "civ_spawn_neochori";
             icon = "\dataM\UI\Spawns\neochori.paa";
             conditions = "[""WideTraveller""] call ULP_fnc_hasPerk";
         };
 
         class Taxi : BaseSpawn {
-            displayName = "Такси на Алтисе";
+            displayName = $STR_SPAWN_TAXI;
             marker = "civ_spawn_taxi";
             icon = "\dataM\UI\Spawns\taxi.paa";
             conditions = "[""Taxi""] call ULP_fnc_hasLicense";
         };
         class Solicitor : BaseSpawn {
-            displayName = "Адвокаты Алтиса";
+            displayName = $STR_SPAWN_SOLICITOR;
             marker = "civ_spawn_solicitor";
             icon = "\dataM\UI\Spawns\solicitor.paa";
             conditions = "[""Solicitor""] call ULP_fnc_hasLicense";
         };
         class News : BaseSpawn {
-            displayName = "AAN World News";
+            displayName = $STR_SPAWN_NEWS;
             marker = "civ_spawn_news";
             icon = "\dataM\UI\Spawns\news.paa";
             conditions = "[""News""] call ULP_fnc_hasLicense";
         };
         class Rebel : BaseSpawn {
-            displayName = "Аутпост повстанцев";
+            displayName = $STR_SPAWN_REBEL_OUTPOST;
             marker = "civ_spawn_rebel";
             icon = "\dataM\UI\Spawns\rebel.paa";
             conditions = "[""Rebel""] call ULP_fnc_hasLicense && { missionNamespace getVariable [""ULP_SRV_Setting_BaseBidsActive"", false] }";
@@ -189,25 +189,25 @@ class CfgSpawns {
 
     class Malden {
         class LaTriniteConstabulary : Police {
-            displayName = "Констабулярия Ла Тринитэ";
+            displayName = $STR_SPAWN_LA_TRINITE_CONSTAB;
             marker = "cop_spawn_1";
             icon = "\a3\ui_f\data\map\LocationTypes\vegetationBroadleaf_CA.paa";
         };
 
         class test : Police {
-            displayName = "Другой вариант";
+            displayName = $STR_SPAWN_LA_TRINITE_OTHER;
             marker = "cop_spawn_2";
             icon = "\a3\ui_f\data\map\LocationTypes\vegetationBroadleaf_CA.paa";
         };
 
         class LaTriniteHospital : Medic {
-            displayName = "Главное управление Ла Тринитэ";
+            displayName = $STR_SPAWN_LA_TRINITE_HOSPITAL;
             marker = "medic_spawn";
             icon = "\a3\ui_f\data\map\VehicleIcons\pictureLogic_ca.paa";
         };
 
         class LaTrinite : BaseSpawn {
-            displayName = "Ла Тринитэ";
+            displayName = $STR_SPAWN_LA_TRINITE;
             marker = "civ_spawn_1";
             icon = "\a3\ui_f\data\map\LocationTypes\vegetationBroadleaf_CA.paa";
         };

--- a/1rp.Altis/Stringtable.xml
+++ b/1rp.Altis/Stringtable.xml
@@ -93,5 +93,165 @@
             <Original>%1 не может позволить себе штраф в размере %2</Original>
             <English>%1 cannot afford a fine of %2</English>
         </Key>
+        <Key ID="STR_PNC_SELECT_WARRANT">
+            <Original>Вы должны выбрать ордер, который вы хотите удалить...</Original>
+            <English>You must select a warrant you wish to clear...</English>
+        </Key>
+        <Key ID="STR_PNC_CLEAR_CONFIRM">
+            <Original>Вы уверены, что хотите очистить ордера для %1...</Original>
+            <English>Are you sure you want to clear the warrants for %1...</English>
+        </Key>
+        <Key ID="STR_PNC_CLEARED">
+            <Original>Вы очистили ордера для &lt;t color='#B92DE0'&gt;%1&lt;/t&gt;</Original>
+            <English>You cleared the warrants for &lt;t color='#B92DE0'&gt;%1&lt;/t&gt;</English>
+        </Key>
+        <Key ID="STR_ADMIN_COOLDOWN">
+            <Original>Вы недавно использовали команду, пожалуйста, подождите перед повторной попыткой...</Original>
+            <English>You recently used this command, please wait before trying again...</English>
+        </Key>
+        <Key ID="STR_ADMIN_NEED_TARGET">
+            <Original>Вам нужно выбрать цель для выполнения этого действия...</Original>
+            <English>You need to select a target to perform this action...</English>
+        </Key>
+        <Key ID="STR_ADMIN_TARGET_SELF">
+            <Original>Нельзя выполнить это действие на себе...</Original>
+            <English>You cannot perform this action on yourself...</English>
+        </Key>
+        <Key ID="STR_ADMIN_EXIT_VEHICLE">
+            <Original>Вам нужно выйти из транспортного средства, прежде чем сделать это...</Original>
+            <English>You need to exit the vehicle before doing this...</English>
+        </Key>
+        <Key ID="STR_ADMIN_TELEPORT_TO">
+            <Original>Вы телепортировались к &lt;t color='#B92DE0'&gt;%1&lt;/t&gt;</Original>
+            <English>You teleported to &lt;t color='#B92DE0'&gt;%1&lt;/t&gt;</English>
+        </Key>
+        <Key ID="STR_ADMIN_TELEPORT_HERE">
+            <Original>Вы телепортировали &lt;t color='#B92DE0'&gt;%1&lt;/t&gt; к себе</Original>
+            <English>You teleported &lt;t color='#B92DE0'&gt;%1&lt;/t&gt; to yourself</English>
+        </Key>
+        <Key ID="STR_SPAWN_KAVALA_HQ">
+            <Original>Штаб-квартира Кавалы</Original>
+            <English>Kavala Headquarters</English>
+        </Key>
+        <Key ID="STR_SPAWN_NCA_FRONTLINE">
+            <Original>Штаб-квартира НСА на передовой</Original>
+            <English>NCA Frontline Headquarters</English>
+        </Key>
+        <Key ID="STR_SPAWN_ATHIRA_POST">
+            <Original>Пост Афиры</Original>
+            <English>Athira Outpost</English>
+        </Key>
+        <Key ID="STR_SPAWN_PYRGOS_POST">
+            <Original>Пост Пироса</Original>
+            <English>Pyrgos Outpost</English>
+        </Key>
+        <Key ID="STR_SPAWN_AGIOS_POST">
+            <Original>Пост Агиоса</Original>
+            <English>Agios Outpost</English>
+        </Key>
+        <Key ID="STR_SPAWN_UNDERCOVER_HQ">
+            <Original>Скрытая штаб-квартира НСА</Original>
+            <English>Undercover NCA HQ</English>
+        </Key>
+        <Key ID="STR_SPAWN_KAVALA_HOSPITAL">
+            <Original>Госпиталь Кавалы</Original>
+            <English>Kavala Hospital</English>
+        </Key>
+        <Key ID="STR_SPAWN_ATHIRA_CLINIC">
+            <Original>Клиника Афиры</Original>
+            <English>Athira Clinic</English>
+        </Key>
+        <Key ID="STR_SPAWN_PYRGOS_CLINIC">
+            <Original>Клиника Пироса</Original>
+            <English>Pyrgos Clinic</English>
+        </Key>
+        <Key ID="STR_SPAWN_AIR_AMBULANCE">
+            <Original>Станция Воздушной скорой помощи</Original>
+            <English>Air Ambulance Station</English>
+        </Key>
+        <Key ID="STR_SPAWN_MARINE_BASE">
+            <Original>Морская база</Original>
+            <English>Marine Base</English>
+        </Key>
+        <Key ID="STR_SPAWN_HATO_KAVALA">
+            <Original>Объект Кавалы</Original>
+            <English>HATO Kavala Compound</English>
+        </Key>
+        <Key ID="STR_SPAWN_HATO_AGIOS">
+            <Original>Объект Агиоса</Original>
+            <English>HATO Agios Compound</English>
+        </Key>
+        <Key ID="STR_SPAWN_GOV_RESIDENCE">
+            <Original>10 улица Кавалы</Original>
+            <English>10 Kavala Street</English>
+        </Key>
+        <Key ID="STR_SPAWN_GOV_OFFICES">
+            <Original>Правительственные офисы</Original>
+            <English>Government Offices</English>
+        </Key>
+        <Key ID="STR_SPAWN_KAVALA_SAFEHOUSE">
+            <Original>Тайник Кавалы</Original>
+            <English>Kavala Safehouse</English>
+        </Key>
+        <Key ID="STR_SPAWN_PYRGOS_SAFEHOUSE">
+            <Original>Тайник Пироса</Original>
+            <English>Pyrgos Safehouse</English>
+        </Key>
+        <Key ID="STR_SPAWN_CIV_KAVALA">
+            <Original>Кавала</Original>
+            <English>Kavala</English>
+        </Key>
+        <Key ID="STR_SPAWN_CIV_ATHIRA">
+            <Original>Афира</Original>
+            <English>Athira</English>
+        </Key>
+        <Key ID="STR_SPAWN_CIV_PYRGOS">
+            <Original>Пирогос</Original>
+            <English>Pyrgos</English>
+        </Key>
+        <Key ID="STR_SPAWN_CIV_SOFIA">
+            <Original>София</Original>
+            <English>Sofia</English>
+        </Key>
+        <Key ID="STR_SPAWN_CIV_AGIOS">
+            <Original>Агиос</Original>
+            <English>Agios</English>
+        </Key>
+        <Key ID="STR_SPAWN_CIV_NEOCHORI">
+            <Original>Неохори</Original>
+            <English>Neochori</English>
+        </Key>
+        <Key ID="STR_SPAWN_TAXI">
+            <Original>Такси на Алтисе</Original>
+            <English>Altis Taxi</English>
+        </Key>
+        <Key ID="STR_SPAWN_SOLICITOR">
+            <Original>Адвокаты Алтиса</Original>
+            <English>Altis Solicitors</English>
+        </Key>
+        <Key ID="STR_SPAWN_NEWS">
+            <Original>AAN World News</Original>
+            <English>AAN World News</English>
+        </Key>
+        <Key ID="STR_SPAWN_REBEL_OUTPOST">
+            <Original>Аутпост повстанцев</Original>
+            <English>Rebel Outpost</English>
+        </Key>
+        <Key ID="STR_SPAWN_LA_TRINITE_CONSTAB">
+            <Original>Констабулярия Ла Тринитэ</Original>
+            <English>La Trinite Constabulary</English>
+        </Key>
+        <Key ID="STR_SPAWN_LA_TRINITE_OTHER">
+            <Original>Другой вариант</Original>
+            <English>Alternative Option</English>
+        </Key>
+        <Key ID="STR_SPAWN_LA_TRINITE_HOSPITAL">
+            <Original>Главное управление Ла Тринитэ</Original>
+            <English>La Trinite Headquarters</English>
+        </Key>
+        <Key ID="STR_SPAWN_LA_TRINITE">
+            <Original>Ла Тринитэ</Original>
+            <English>La Trinite</English>
+        </Key>
     </Package>
 </Project>


### PR DESCRIPTION
## Summary
- localize warrant clearing messages
- localize admin camera action prompts
- add Stringtable keys for spawn point names
- use these new `$STR_*` references in spawn configuration

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68700778af888332b8e0940401bfca73