### PR TITLE
Add localization for UI dialogs

### DIFF
--- a/1rp.Altis/Functions/Money/fn_switchBank.sqf
+++ b/1rp.Altis/Functions/Money/fn_switchBank.sqf
@@ -19,7 +19,7 @@ if (isNull _display) exitWith {};
 private _group = (_index isEqualTo 1);
 
 if (_group && { !([] call ULP_fnc_isGroup) }) exitWith {
-    ["Для доступа к этой функции вам нужно находиться в группе!"] call ULP_fnc_hint;
+    [localize "STR_UI_MUST_BE_IN_GROUP"] call ULP_fnc_hint;
     _ctrl lbSetCurSel 0;
     [_ctrl, 0] call ULP_fnc_switchBank;
 };
@@ -47,8 +47,9 @@ reverse _transactions;
 
 private _balValue = [BANK, [] call ULP_fnc_groupFunds] select (_group);
 
-_balance ctrlSetStructuredText parseText format["<t align='left'>%1</t><t align='right'>%2%3</t><br/><t size='0.9'>Баланс<t align='right'>Налог</t></t>", 
-    ([format["%1%2", "$", [_balValue] call ULP_fnc_numberText], "-"] select (_balValue <= 0)), (([] call ULP_fnc_groupTax) * 100), "%"
+_balance ctrlSetStructuredText parseText format["<t align='left'>%1</t><t align='right'>%2%3</t><br/><t size='0.9'>%4<t align='right'>%5</t></t>",
+    ([format["%1%2", "$", [_balValue] call ULP_fnc_numberText], "-"] select (_balValue <= 0)), (([] call ULP_fnc_groupTax) * 100), "%",
+    localize "STR_UI_BALANCE", localize "STR_UI_TAX"
 ];
 
 (_display displayCtrl 4108) ctrlShow !(_group);

--- a/1rp.Altis/Functions/VirtualInventory/fn_openInventory.sqf
+++ b/1rp.Altis/Functions/VirtualInventory/fn_openInventory.sqf
@@ -38,8 +38,8 @@ if (createDialog "DialogInventory") exitWith {
 		"", "_missionCfg", "_picture", "_name"
 	];
 	
-	private _title = _display displayCtrl 4201;
-	_title ctrlSetStructuredText parseText "Inventory";
+    private _title = _display displayCtrl 4201;
+    _title ctrlSetStructuredText parseText localize "STR_UI_INVENTORY";
 	_display setVariable ["lastUser", objNull];
 
 	private _filter = _display displayCtrl 23032;
@@ -84,7 +84,7 @@ if (createDialog "DialogInventory") exitWith {
 		};
 
 		if ((_container distance player) > 10) exitWith {
-                        ["Вы слишком далеко от контейнера, чтобы получить к нему доступ!"] call ULP_fnc_hint;
+                        [localize "STR_UI_FAR_FROM_CONTAINER"] call ULP_fnc_hint;
 			closeDialog 0;
 
 			[_container, player] remoteExecCall ["ULP_SRV_fnc_unregisterCargoUser", RSERV];
@@ -100,8 +100,8 @@ if (createDialog "DialogInventory") exitWith {
 
 		private _curUser = _container getVariable ["ULP_VirtualCargo_User", objNull];
 		if !((_display getVariable ["lastUser", objNull]) isEqualTo _curUser) then {
-			private _title = _display displayCtrl 4201;
-			_title ctrlSetStructuredText parseText format["Inventory <t align='right'>User: %1</t>", name _curUser];
+                        private _title = _display displayCtrl 4201;
+                        _title ctrlSetStructuredText parseText format[localize "STR_UI_INVENTORY_USER", name _curUser];
 			_display setVariable ["lastUser", _curUser];
 		};
 	}] call ULP_fnc_addEachFrame)];

--- a/1rp.Altis/Functions/VirtualInventory/fn_updateInventory.sqf
+++ b/1rp.Altis/Functions/VirtualInventory/fn_updateInventory.sqf
@@ -65,8 +65,8 @@ private _addItem = {
 if (_type isEqualTo 0) then {
 	ULP_CarryInfo params ["_carryWeight", "_maxWeight"];
 
-	private _personalTitle = _display displayCtrl 4202;
-	_personalTitle ctrlSetStructuredText parseText format["Личный Инвентарь<t align='right'>%1/%2</t>", _carryWeight, _maxWeight];
+    private _personalTitle = _display displayCtrl 4202;
+    _personalTitle ctrlSetStructuredText parseText format["%1<t align='right'>%2/%3</t>", localize "STR_UI_PERSONAL_INVENTORY", _carryWeight, _maxWeight];
 
 	private _list = _display displayCtrl 4204;
 	lnbClear _list;
@@ -79,8 +79,8 @@ if (_type isEqualTo 0) then {
 
 	(_display displayCtrl 4205) ctrlEnable (((lbSize _list) > 0) && { [_container] call ULP_fnc_isCargoUser });
 } else {
-	private _containerTitle = _display displayCtrl 4206;
-	_containerTitle ctrlSetStructuredText parseText format["Инвентарь Контейнера<t align='right'>%1/%2</t>", [_container] call ULP_fnc_currentLoad, [_container] call ULP_fnc_maxLoad];
+    private _containerTitle = _display displayCtrl 4206;
+    _containerTitle ctrlSetStructuredText parseText format["%1<t align='right'>%2/%3</t>", localize "STR_UI_CONTAINER_INVENTORY", [_container] call ULP_fnc_currentLoad, [_container] call ULP_fnc_maxLoad];
 
 	private _list = _display displayCtrl 4208;
 	lnbClear _list;

--- a/1rp.Altis/Stringtable.xml
+++ b/1rp.Altis/Stringtable.xml
@@ -253,5 +253,123 @@
             <Original>Ла Тринитэ</Original>
             <English>La Trinite</English>
         </Key>
+
+        <!-- UI localization -->
+        <Key ID="STR_UI_GARAGE">
+            <Original>Гараж</Original>
+            <English>Garage</English>
+        </Key>
+        <Key ID="STR_UI_RETRIEVE">
+            <Original>&lt;t align='center'&gt;Получить&lt;/t&gt;</Original>
+            <English>&lt;t align='center'&gt;Retrieve&lt;/t&gt;</English>
+        </Key>
+        <Key ID="STR_UI_DESTROY">
+            <Original>&lt;t align='center'&gt;Уничтожить&lt;/t&gt;</Original>
+            <English>&lt;t align='center'&gt;Destroy&lt;/t&gt;</English>
+        </Key>
+        <Key ID="STR_UI_TRANSFER">
+            <Original>&lt;t align='center'&gt;Передать&lt;/t&gt;</Original>
+            <English>&lt;t align='center'&gt;Transfer&lt;/t&gt;</English>
+        </Key>
+        <Key ID="STR_UI_BANK">
+            <Original>Банк</Original>
+            <English>Bank</English>
+        </Key>
+        <Key ID="STR_UI_PERSONAL_TAB">
+            <Original>Личный</Original>
+            <English>Personal</English>
+        </Key>
+        <Key ID="STR_UI_GROUP_TAB">
+            <Original>Группа</Original>
+            <English>Group</English>
+        </Key>
+        <Key ID="STR_UI_TRANSACTION">
+            <Original>Транзакция</Original>
+            <English>Transaction</English>
+        </Key>
+        <Key ID="STR_UI_IN">
+            <Original>Вход</Original>
+            <English>In</English>
+        </Key>
+        <Key ID="STR_UI_OUT">
+            <Original>Выход</Original>
+            <English>Out</English>
+        </Key>
+        <Key ID="STR_UI_WITHDRAW">
+            <Original>&lt;t align='center'&gt;Снять&lt;/t&gt;</Original>
+            <English>&lt;t align='center'&gt;Withdraw&lt;/t&gt;</English>
+        </Key>
+        <Key ID="STR_UI_DEPOSIT">
+            <Original>&lt;t align='center'&gt;Внести&lt;/t&gt;</Original>
+            <English>&lt;t align='center'&gt;Deposit&lt;/t&gt;</English>
+        </Key>
+        <Key ID="STR_UI_TRANSFER_BTN">
+            <Original>&lt;t align='center'&gt;Перевести&lt;/t&gt;</Original>
+            <English>&lt;t align='center'&gt;Transfer&lt;/t&gt;</English>
+        </Key>
+        <Key ID="STR_UI_PERSONAL_INVENTORY">
+            <Original>Персональный инвентарь</Original>
+            <English>Personal Inventory</English>
+        </Key>
+        <Key ID="STR_UI_CONTAINER_INVENTORY">
+            <Original>Инвентарь контейнера</Original>
+            <English>Container Inventory</English>
+        </Key>
+        <Key ID="STR_UI_ITEM">
+            <Original>Предмет</Original>
+            <English>Item</English>
+        </Key>
+        <Key ID="STR_UI_TOTAL">
+            <Original>Всего</Original>
+            <English>Total</English>
+        </Key>
+        <Key ID="STR_UI_BALANCE">
+            <Original>Баланс</Original>
+            <English>Balance</English>
+        </Key>
+        <Key ID="STR_UI_TAX">
+            <Original>Налог</Original>
+            <English>Tax</English>
+        </Key>
+        <Key ID="STR_UI_TOOLTIP_TO_CONTAINER">
+            <Original>Передать в контейнер</Original>
+            <English>Move to container</English>
+        </Key>
+        <Key ID="STR_UI_TOOLTIP_TO_PERSONAL">
+            <Original>Передать себе</Original>
+            <English>Move to self</English>
+        </Key>
+        <Key ID="STR_UI_INVENTORY">
+            <Original>Инвентарь</Original>
+            <English>Inventory</English>
+        </Key>
+        <Key ID="STR_UI_INVENTORY_USER">
+            <Original>Инвентарь &lt;t align='right'&gt;Пользователь: %1&lt;/t&gt;</Original>
+            <English>Inventory &lt;t align='right'&gt;User: %1&lt;/t&gt;</English>
+        </Key>
+        <Key ID="STR_UI_FAR_FROM_CONTAINER">
+            <Original>Вы слишком далеко от контейнера, чтобы получить к нему доступ!</Original>
+            <English>You are too far from the container to access it!</English>
+        </Key>
+        <Key ID="STR_UI_MUST_BE_IN_GROUP">
+            <Original>Для доступа к этой функции вам нужно находиться в группе!</Original>
+            <English>You need to be in a group to access this function!</English>
+        </Key>
+        <Key ID="STR_UI_SELECT_RECIPIENT">
+            <Original>Вы не выбрали получателя для перевода!</Original>
+            <English>You did not select a recipient for the transfer!</English>
+        </Key>
+        <Key ID="STR_UI_WAIT_REVIVE">
+            <Original>&lt;t align='left' size='1'&gt;Ожидание возрождения...&lt;/t&gt;&lt;t align='right' size='1'&gt;Ближайший медик: ##м&lt;/t&gt;</Original>
+            <English>&lt;t align='left' size='1'&gt;Waiting for revive...&lt;/t&gt;&lt;t align='right' size='1'&gt;Nearest medic: ##m&lt;/t&gt;</English>
+        </Key>
+        <Key ID="STR_UI_BLEEDING">
+            <Original>&lt;t align='center' size='1'&gt;Вы кровоточите...&lt;/t&gt;</Original>
+            <English>&lt;t align='center' size='1'&gt;You are bleeding...&lt;/t&gt;</English>
+        </Key>
+        <Key ID="STR_UI_REQUEST_MEDIC">
+            <Original>&lt;t align='center' size='1'&gt;Нажмите &lt;t color='#8A2BE2'&gt;Пробел&lt;/t&gt; для вызова медика&lt;/t&gt;</Original>
+            <English>&lt;t align='center' size='1'&gt;Press &lt;t color='#8A2BE2'&gt;Space&lt;/t&gt; to request a medic&lt;/t&gt;</English>
+        </Key>
     </Package>
 </Project>

--- a/1rp.Altis/UI/DialogGarage/DialogGarage.hpp
+++ b/1rp.Altis/UI/DialogGarage/DialogGarage.hpp
@@ -14,7 +14,7 @@ class DialogGarage {
 		class Header : Life_RscText {
             idc = -1;
             colorBackground[] = HEADER_COLOUR;
-            text = "Гараж";
+            text = $STR_UI_GARAGE;
             SAFEZONE_X(UI_X);
             SAFEZONE_Y(0.269);
 			SAFEZONE_W(UI_WIDTH);
@@ -86,7 +86,7 @@ class DialogGarage {
 
 		class RetrieveButton : Life_RscButtonCenter {
             idc = 3505;
-            text = "<t align = 'center'>Получить</t>";
+            text = $STR_UI_RETRIEVE;
 			onButtonClick = "_this call ULP_fnc_retrieveGarage;";
             SAFEZONE_X(0.64265625);
             SAFEZONE_Y(0.698 + BUTTON_MARGIN_Y);
@@ -96,7 +96,7 @@ class DialogGarage {
 
 		class DestroyButton : Life_RscButtonCenter {
             idc = 3506;
-            text = "<t align = 'center'>Уничтожить</t>";
+            text = $STR_UI_DESTROY;
 			onButtonClick = "_this call ULP_fnc_destroyGarage;";
             SAFEZONE_X(0.64265625 - (0.0584375) - MARGIN_X);
             SAFEZONE_Y(0.698 + BUTTON_MARGIN_Y);
@@ -106,7 +106,7 @@ class DialogGarage {
 
 		class TransferButton : Life_RscButtonCenter {
             idc = 3507;
-            text = "<t align = 'center'>Передать</t>";
+            text = $STR_UI_TRANSFER;
 			onButtonClick = "_this call ULP_fnc_transferGarage;";
             SAFEZONE_X(0.64265625 - (0.0584375 * 2) - (MARGIN_X * 2));
             SAFEZONE_Y(0.698 + BUTTON_MARGIN_Y);

--- a/1rp.Altis/UI/DialogInventory/DialogInventory.hpp
+++ b/1rp.Altis/UI/DialogInventory/DialogInventory.hpp
@@ -16,7 +16,7 @@ class DialogInventory {
 		class Header : Life_RscStructuredText {
 			idc = 4201;
 			colorBackground[] = HEADER_COLOUR;
-			text = "Инвентарь контейнера";
+                        text = $STR_UI_CONTAINER_INVENTORY;
 			SAFEZONE_X(UI_X);
 			SAFEZONE_Y(BODY_Y - BUTTON_H);
 			SAFEZONE_W(UI_WIDTH);
@@ -98,7 +98,7 @@ class DialogInventory {
 
 		class Personal : Life_RscStructuredText {
 			idc = 4202;
-			text = "Персональный инвентарь<t align='right'>0/0</t>";
+                        text = $STR_UI_PERSONAL_INVENTORY;
 			SAFEZONE_X(UI_X + MARGIN_X);
 			SAFEZONE_Y(BODY_CONTENT_LIST_Y);
 			SAFEZONE_W((((UI_WIDTH - (MARGIN_X * 2)) / 2) - (MARGIN_X / 2)));
@@ -122,11 +122,11 @@ class DialogInventory {
 
 			class Items {
 				class DisplayName {
-					text = "Предмет";
+                                        text = $STR_UI_ITEM;
 					value = 0;
 				};
 				class Count {
-					text = "Всего";
+                                        text = $STR_UI_TOTAL;
 					value = -1;
 					data = "data";
 				};
@@ -151,7 +151,7 @@ class DialogInventory {
 		class ToInventory : ULP_RscButtonIconNoAnim {
 			idc = 4205;
 			text = "\A3\Ui_f\data\GUI\RscCommon\RscHTML\arrow_right_ca.paa";
-			tooltip = "Передать в контейнер";
+                        tooltip = $STR_UI_TOOLTIP_TO_CONTAINER;
 			colorBackground[] = {0,0,0,1};
             colorFocused[] = {0.09,0.09,0.09,1};
             colorBackgroundActive[] = {0.03,0.03,0.03,1};
@@ -173,7 +173,7 @@ class DialogInventory {
 
 		class Container : Personal {
 			idc = 4206;
-			text = "Инвентарь контейнера<t align='right'>0/0</t>";
+                        text = $STR_UI_CONTAINER_INVENTORY;
 			SAFEZONE_X(CONTAINER_X);
 		};
 
@@ -190,7 +190,7 @@ class DialogInventory {
 		class ToPersonal : ToInventory {
 			idc = 4209;
 			text = "\A3\Ui_f\data\GUI\RscCommon\RscHTML\arrow_left_ca.paa";
-			tooltip = "Передать себе";
+                        tooltip = $STR_UI_TOOLTIP_TO_PERSONAL;
 			onButtonClick = "_this call ULP_fnc_takeFromCargo;";
 			SAFEZONE_X(CONTAINER_X);
 		};

--- a/1rp.Altis/UI/DialogMoney/DialogMoney.hpp
+++ b/1rp.Altis/UI/DialogMoney/DialogMoney.hpp
@@ -13,7 +13,7 @@ class DialogMoney {
 		class Header : Life_RscText {
 			idc = -1;
 			colorBackground[] = HEADER_COLOUR;
-			text = "Банк";
+                        text = $STR_UI_BANK;
 			SAFEZONE_X(UI_X);
 			SAFEZONE_Y(BODY_Y - 0.022);
 			SAFEZONE_W(UI_WIDTH);
@@ -63,19 +63,19 @@ class DialogMoney {
 			SAFEZONE_H(0.022);
 			columns = 2;
 			fade = 0;
-			strings[] = {
-				"Личный",
-				"Группа"
-			};
-			tooltips[] = {
-				"Личный",
-				"Группа"
-			};
+                        strings[] = {
+                                "$STR_UI_PERSONAL_TAB",
+                                "$STR_UI_GROUP_TAB"
+                        };
+                        tooltips[] = {
+                                "$STR_UI_PERSONAL_TAB",
+                                "$STR_UI_GROUP_TAB"
+                        };
 		};
 
 		class Personal : Life_RscStructuredText {
 			idc = 4102;
-			text = "<t align='left'>$1,000,000</t><t align='right'>1.5%</t><br/><t size='0.9'>Баланс<t align='right'>Налог</t></t>";
+                        text = ""; // will be set by script
 			colorBackground[] = INNER_BODY_COLOUR;
 			SAFEZONE_X(UI_X + MARGIN_X);
 			SAFEZONE_Y((BODY_Y + BODY_HEIGHT) - (0.022 * 2) - MARGIN_Y);
@@ -110,17 +110,17 @@ class DialogMoney {
 
 			class Items {
 				class DisplayName {
-					text = "Транзакция";
+                                        text = $STR_UI_TRANSACTION;
 					value = 1;
                     data = "data";
 				};
 				class Weight {
-					text = "Вход";
+                                        text = $STR_UI_IN;
 					value = -1;
 					data = "data";
 				};
 				class Legal {
-					text = "Выход";
+                                        text = $STR_UI_OUT;
 					value = -1;
 					data = "data";
 				};
@@ -144,7 +144,7 @@ class DialogMoney {
 
 		class Withdraw : Life_RscButtonCenter {
 			idc = 4106;
-			text = "<t align = 'center'>Снять</t>";
+                        text = $STR_UI_WITHDRAW;
 			onButtonClick = "_this call ULP_fnc_withdrawMoney";
 			SAFEZONE_X((UI_X + UI_WIDTH - (UI_WIDTH / 4)) - MARGIN_X);
 			SAFEZONE_Y((BODY_Y + BODY_HEIGHT) + BUTTON_MARGIN_Y);
@@ -154,7 +154,7 @@ class DialogMoney {
 
 		class Deposit : Life_RscButtonCenter {
 			idc = 4107;
-			text = "<t align = 'center'>Внести</t>";
+                        text = $STR_UI_DEPOSIT;
 			onButtonClick = "_this call ULP_fnc_depositMoney";
 			SAFEZONE_X((UI_X + UI_WIDTH - ((UI_WIDTH / 4) * 2)) - (MARGIN_X * 2));
 			SAFEZONE_Y((BODY_Y + BODY_HEIGHT) + BUTTON_MARGIN_Y);
@@ -164,8 +164,8 @@ class DialogMoney {
 
 		class Transfer : Life_RscButtonCenter {
 			idc = 4108;
-			text = "<t align = 'center'>Перевести</t>";
-			onButtonClick = "[(findDisplay getNumber(configFile >> ""RscDisplayMission"" >> ""idd"")), [""Police"", ""Medic"", ""Hato"", ""Civilian""], [], { _this params [[""_display"", displayNull, [displayNull]]]; if (isNull _display) exitWith {}; private _list = _display displayCtrl 3809; private _unit = (_list tvData (tvCurSel _list)) call BIS_fnc_objectFromNetId; if (isNull _unit) exitWith { [""Вы не выбрали получателя для перевода!""] call ULP_fnc_hint; }; [0.01, [_unit], { [_this select 0, true] call ULP_fnc_giveMoney }] call ULP_fnc_waitExecute; }, false, false] call ULP_fnc_selectPlayer;";
+                        text = $STR_UI_TRANSFER_BTN;
+			onButtonClick = "[(findDisplay getNumber(configFile >> ""RscDisplayMission"" >> ""idd"")), [""Police"", ""Medic"", ""Hato"", ""Civilian""], [], { _this params [[""_display"", displayNull, [displayNull]]]; if (isNull _display) exitWith {}; private _list = _display displayCtrl 3809; private _unit = (_list tvData (tvCurSel _list)) call BIS_fnc_objectFromNetId; if (isNull _unit) exitWith { [localize "STR_UI_SELECT_RECIPIENT"] call ULP_fnc_hint; }; [0.01, [_unit], { [_this select 0, true] call ULP_fnc_giveMoney }] call ULP_fnc_waitExecute; }, false, false] call ULP_fnc_selectPlayer;";
 			SAFEZONE_X((UI_X + UI_WIDTH - ((UI_WIDTH / 4) * 3)) - (MARGIN_X * 3));
 			SAFEZONE_Y((BODY_Y + BODY_HEIGHT) + BUTTON_MARGIN_Y);
 			SAFEZONE_W((UI_WIDTH / 4));

--- a/1rp.Altis/UI/RscIncapacitated/RscIncapacitated.hpp
+++ b/1rp.Altis/UI/RscIncapacitated/RscIncapacitated.hpp
@@ -29,7 +29,7 @@ class RscIncapacitated {
 
         class SubText : Life_RscStructuredText {
             idc = 9002;
-            text = "<t align='left' size='1'>Ожидание возрождения...</t><t align='right' size='1'>Ближайший медик: ##м</t>";
+            text = $STR_UI_WAIT_REVIVE;
             x = 0.376251 * safezoneW + safezoneX;
             y = 0.764 * safezoneH + safezoneY;
             w = 0.2475 * safezoneW;
@@ -56,7 +56,7 @@ class RscIncapacitated {
 
         class ProgressText : Life_RscStructuredText {
             idc = 9003;
-            text = "<t align='center' size='1'>Вы кровоточите...</t>";
+            text = $STR_UI_BLEEDING;
             x = 0.376251 * safezoneW + safezoneX;
             y = 0.729 * safezoneH + safezoneY;
             w = 0.2475 * safezoneW;
@@ -65,7 +65,7 @@ class RscIncapacitated {
 
         class RequestMedic : Life_RscStructuredText {
             idc = 9005;
-            text = "<t align='center' size='1'>Нажмите <t color='#8A2BE2'>Пробел</t> для вызова медика</t>";
+            text = $STR_UI_REQUEST_MEDIC;
             x = 0.29375 * safezoneW + safezoneX;
             y = 0.792 * safezoneH + safezoneY;
             w = 0.4125 * safezoneW;


### PR DESCRIPTION
## Summary
- add initial UI translations in `Stringtable.xml`
- use localized strings in garage, money, inventory and incapacitated UIs
- show localized messages in inventory and bank scripts

## Testing
- `true`

------
https://chatgpt.com/codex/tasks/task_e_687016b519f08332b1b8cd2552a60136